### PR TITLE
Return meaningful exit status depending on compilation result

### DIFF
--- a/compiler_linux.go
+++ b/compiler_linux.go
@@ -59,6 +59,7 @@ func (ci linuxCompiler) Compile(path, objDir string, options *CompilerOptions) e
 	}
 
 	// Add additional compiler flags for C++
+	fileext := filepath.Ext(path)
 	if fileext != ".c" {
 		for _, flag := range options.CompilerFlagsCPP {
 			args = append(args, flag)

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	ctx, err := NewContext()
 	if err != nil {
 		log.Fatal("Unable to initialize context: %s", err.Error())
-		return
+		os.Exit(1)
 	}
 
 	// Find the name of the project
@@ -174,12 +174,12 @@ func main() {
 	ctx.SourceFiles, err = getSourceFiles()
 	if err != nil {
 		log.Fatal("Unable to read directory: %s", err.Error())
-		return
+		os.Exit(1)
 	}
 
 	if len(ctx.SourceFiles) == 0 {
 		log.Warn("No source files found!")
-		return
+		os.Exit(1)
 	}
 
 	// Make a temporary folder for .obj files
@@ -195,7 +195,7 @@ func main() {
 	// Stop if there were any compiler errors
 	if ctx.CompilerErrors > 0 {
 		log.Fatal("😢 Compilation failed!")
-		return
+		os.Exit(1)
 	}
 
 	// Perform the linking
@@ -207,7 +207,7 @@ func main() {
 	if err != nil {
 		log.Fatal("😢 Link failed!")
 		log.Fatal("%s", err.Error())
-		return
+		os.Exit(1)
 	}
 
 	// Report succcess


### PR DESCRIPTION
Thanks for making the awesome qb!

This pull request changes qb so that when compilation fails or qb encounters other errors, exit with the exit code of 1 instead of just doing `return` from main which seems to result in the exit code 0.

This will enable doing things like `qb && ./program` in order to compile the program and then run it if but only if compilation was successful. 

Also I am including a fix that I needed to do in order to compile qb. I believe the regression was introduced in 29539608bd391d8383aa0b0650f99ad35829b2e2. You might want to check `compiler_darwin.go` too.